### PR TITLE
simple fix to allow mode as an identifier

### DIFF
--- a/Language/Lustre/Parser.y
+++ b/Language/Lustre/Parser.y
@@ -728,6 +728,7 @@ name :: { Name }
 
 label :: { Label }
   : IDENT                { toLabel $1 }
+  | 'mode'               { Label "mode" $1 }
 
 ident :: { Ident }
   : label                 { toIdent $1 }


### PR DESCRIPTION
Since some tools use "mode" as an identifier, we can allow it with no change to the lexer with a special case in the `label` non-terminal.

Allows fixing https://github.com/GaloisInc/lustre-sally/issues/13